### PR TITLE
fix: ajuste ruta carga de firma electrónica

### DIFF
--- a/api.py
+++ b/api.py
@@ -374,7 +374,7 @@ class ElectronicSign:
                 pdf abierto en buffer como lectura
         """
 
-        signPdf = PdfFileReader(open("signature.pdf", "rb"))
+        signPdf = PdfFileReader(open("documents/signature.pdf", "rb"))
         documentPdf = PdfFileReader(pdfIn)
         
         # Get our files ready


### PR DESCRIPTION
No conseguía encontrar el documento por ruta errónea, lo cual causaba que por el servicio arrojase error 500 por file not found. Este error solo sucedía al estampar firma al final de página existente, en página nueva funciona perfecto.