### PR TITLE
fix: Corregir decodificación de respuesta en getAll()

### DIFF
--- a/controllers/document.py
+++ b/controllers/document.py
@@ -310,8 +310,9 @@ def getAll(params, nuxeo: Nuxeo):
         docCrudQueryCount = 0
         for url in urlsDocuments:
             res_doc_crud = get_json(str(os.environ['DOCUMENTOS_CRUD_URL'])+'documento'+url+'&fields=Id,Enlace,Nombre&sortby=Id&order=asc', target=None)
+            res_doc_crud = res_doc_crud.content.decode('utf8')
             try:
-                res_json = obtener_respuesta(res_doc_crud.json())
+                res_json = obtener_respuesta(res_doc_crud)
                 if res_json != [{}]:
                     listUUIDS += res_json
                     docCrudQueryCount+=1


### PR DESCRIPTION
Se corrigió un error en la función getAll() del controlador de documentos. Se agregó una línea de código para decodificar la respuesta obtenida de la API de documentos CRUD antes de procesarla. Esto soluciona un problema de codificación incorrecta que causaba errores en la obtención de documentos.  udistrital/sga_documentacion#454